### PR TITLE
Add window title management to MacOSX backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -442,7 +442,8 @@ class NavigationToolbarMac(_macosx.NavigationToolbar):
         self.canvas.invalidate()
 
     def save_figure(self, *args):
-        filename = _macosx.choose_save_file('Save the figure')
+        filename = _macosx.choose_save_file('Save the figure',
+                                            self.canvas.get_default_filename())
         if filename is None: # Cancel
             return
         self.canvas.print_figure(filename)
@@ -466,7 +467,8 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
         _macosx.set_cursor(cursor)
 
     def save_figure(self, *args):
-        filename = _macosx.choose_save_file('Save the figure')
+        filename = _macosx.choose_save_file('Save the figure',
+                                            self.canvas.get_default_filename())
         if filename is None: # Cancel
             return
         self.canvas.print_figure(filename)


### PR DESCRIPTION
Tested very lightly so far, but I was able to change my window title (to a unicode string, even) and when I clicked on the save icon, the default filename was set.
